### PR TITLE
Use setuptools for the installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,8 @@ import os
 import shutil
 import subprocess
 import sys
-from distutils.core import setup
-from distutils.command.install import install
-
+from setuptools import setup
+from setuptools.command.install import install
 
 ## manpage install code taken from https://github.com/novel/lc-tools
 def abspath(path):


### PR DESCRIPTION
`pip` reports errors by using `distutils` functions, so switching to `setuptools` solves the problem. 

Error:

```
Installing collected packages: PyFi
  Running setup.py install for PyFi
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: -c --help [cmd1 cmd2 ...]
       or: -c --help-commands
       or: -c cmd --help

    error: option --single-version-externally-managed not recognized
    Complete output from command /Users/tm/.virtualenvs/adm/bin/python -c "import setuptools;__file__='/var/folders/mn/q9k1gvpd7216sv3q277d1v540000gn/T/pip-7SUHnC-build/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --single-version-externally-managed --record /var/folders/mn/q9k1gvpd7216sv3q277d1v540000gn/T/pip-UQGWHE-record/install-record.txt --install-headers /Users/tm/.virtualenvs/adm/include/site/python2.7:
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]

   or: -c --help [cmd1 cmd2 ...]

   or: -c --help-commands

   or: -c cmd --help

error: option --single-version-externally-managed not recognized

----------------------------------------
Command /Users/tm/.virtualenvs/adm/bin/python -c "import setuptools;__file__='/var/folders/mn/q9k1gvpd7216sv3q277d1v540000gn/T/pip-7SUHnC-build/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --single-version-externally-managed --record /var/folders/mn/q9k1gvpd7216sv3q277d1v540000gn/T/pip-UQGWHE-record/install-record.txt --install-headers /Users/tm/.virtualenvs/adm/include/site/python2.7 failed with error code 1 in /var/folders/mn/q9k1gvpd7216sv3q277d1v540000gn/T/pip-7SUHnC-build
```

Tested on MacOSX and installing via `pip install .`
