### PR TITLE
allow user to use unsafe (e.g., http connection) to api server

### DIFF
--- a/bin/fifo
+++ b/bin/fifo
@@ -65,7 +65,8 @@ parser.add_argument("--config", "-c",
                     default=config.get('GENERAL', 'active'),
                     help="Selects the network config to use")
 parser.add_argument("--api-version", help="The api version to use (e.g., " + DEFAULT_APIVERSION + ")")
-parser.add_argument("--host", help="The host to use (dns or ip no https://)")
+parser.add_argument("--host", help="The host to use (dns or ip, no https://)")
+parser.add_argument("--unsafe", action='store_true', default=False, help="disable https connection, use unsafe http instead")
 parser.add_argument("--user", '-u', help="The user to log in with.")
 parser.add_argument("--password", '-P', help="The password to log in with.")
 parser.add_argument("--verbose", "-v", action='store_true', default=False, help="Turn on verbose mode")
@@ -109,7 +110,7 @@ token = False
 if config.has_option(active_config, 'token'):
     token = config.get(active_config, 'token')
 
-wiggle.init(host, user, pw, token, apiVersion)
+wiggle.init(host, user, pw, token, apiVersion, args.unsafe)
 #We check if we can get a valid token from wiggle and store it on our config
 if wiggle.get_token():
     config.set(active_config, 'token', wiggle.get_token())

--- a/fifo/api/wiggle.py
+++ b/fifo/api/wiggle.py
@@ -11,8 +11,9 @@ class Wiggle:
         self._token = False
         self._apiEndpoint = '/api/0.1.0/'
 
-    def init(self, host, user, pw, token, apiVersion):
+    def init(self, host, user, pw, token, apiVersion, unsafe):
         self.host = host
+        self.unsafe = unsafe
         self.headers = {'Content-type': 'application/json;charset=UTF-8',
                 'Accept': 'application/json'}
         if apiVersion:
@@ -24,7 +25,10 @@ class Wiggle:
             self.connect(user, pw)
 
     def conn(self):
-        return httplib.HTTPSConnection(self.host)
+        if self.unsafe:
+            return httplib.HTTPConnection(self.host)
+        else:
+            return httplib.HTTPSConnection(self.host)
 
     def get_token(self):
         return self._token


### PR DESCRIPTION
sometimes this is necessary, since the api server may be remote, and
just can not provide a https connection.
