### PR TITLE
Fix in User Create

### DIFF
--- a/doc/fifo-users.1
+++ b/doc/fifo-users.1
@@ -35,7 +35,7 @@ Please mind that roles will not be automatically removed from the
 user. While this will not cause problems it might end up cluttering
 the data base.
 .TP
-users create [\-p] [\-\-password|\-P PASS] [\-\-role|\-g ROLE] [\-\-organization|\-o ORG] NAME
+users create [\-p] [\-\-userpassword|\-U PASS] [\-\-role|\-g ROLE] [\-\-organization|\-o ORG] NAME
 Creates a new user and optionally sets the password, role and orgnaistation. If \-p is passed only the UUID is returned.
 .TP
 users sign USER [\-\-csr CSR] [\-\-comment COMMENT]

--- a/fifo/api/user.py
+++ b/fifo/api/user.py
@@ -18,11 +18,11 @@ user_fmt = {
 
 
 def user_create(args):
-    if not args.password:
-        print 'You have to specify a passwrd'
+    if not args.userpassword:
+        print 'You have to specify a userpassword'
         exit(1)
     wiggle = args.endpoint._wiggle
-    reply = args.endpoint.create(args.name, args.password)
+    reply = args.endpoint.create(args.name, args.userpassword)
     if reply:
         if args.organization:
             args.endpoint.join_org(reply['uuid'], args.organization)
@@ -38,7 +38,7 @@ def user_create(args):
                 print 'User creation failed: %r' % reply
                 exit(1)
     else:
-        print 'Faied to create VM.'
+        print 'Faied to create User.'
 
 def grant(args):
     res = args.endpoint.grant(args.uuid, args.permission)
@@ -148,7 +148,7 @@ class User(Entity):
         parser_users_create.add_argument('name',
                                          help='Name of the user')
         parser_users_create.add_argument('-p', action='store_true')
-        parser_users_create.add_argument('--password', '-P',
+        parser_users_create.add_argument('--userpassword', '-U',
                                          help='Password of the user.')
         parser_users_create.add_argument('--role', '-g',
                                          help='Role of the user.')


### PR DESCRIPTION
Fix in user create, adding seperate --userpassword -U flag for user, so that doesnt mash over the requesting user with the --password flag.

```
fifo --curl -c dev users create --password password123 test@test.com
> [curl] curl -X GET "http://192.168.221.201/api/2/sessions/OznWweOQWOKHcOBKZMdM1uuxvvxEiAW7" -H "content-type:application/json;charset=UTF-8" -H "accept:application/json"   
> [curl] curl -X POST "http://192.168.221.201/api/2/oauth/token" -H "content-type:application/json;charset=UTF-8" -H "accept:application/json" -d "username=ppreston%40lucera.com&password=password123&grant_type=password"  
> [curl] curl -X POST "http://192.168.221.201/api/2/users" -H "content-type:application/json;charset=UTF-8" -H "accept:application/json" -d "{\"password\": \"password123\", \"user\": \"test@test.com\"}"  
401
Faied to create VM
```

You can see that the password in authentication is picking up the new user password.

Thanks

Phil